### PR TITLE
Cluster Name added in Testkube

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   cluster-name:
     description: "Cluster name of test suite is hosted"
     required: true
-    default: "ops"
+    default: "env-name"
 
 outputs:
   time: # id of output

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Enable debug output during the action run"
     required: false
     default: "false"
+  cluster-name:
+    description: "Cluster name of test suite is hosted"
+    required: true
+    default: "ops"
 
 outputs:
   time: # id of output
@@ -19,3 +23,4 @@ runs:
   args:
     - ${{ inputs.test-suite-name }}
     - ${{ inputs.enable-debug }}
+    - ${{ inputs.cluster-name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 TEST_SUITE_NAME=$1
 ENABLE_DEBUG=$2
+CLUSTER_NAME=$3
 
 set -e
 
@@ -15,7 +16,7 @@ echo "Running TestSuite: ${TEST_SUITE_NAME}"
 time=$(date)
 # echo "::set-output name=time::$time"
 
-aws eks update-kubeconfig --name ops
+aws eks update-kubeconfig --name ${CLUSTER_NAME}
 
 kubectl version
 


### PR DESCRIPTION
**What does this do?**
The github actions module to run testing had fixed cluster ops, the cluster ops input parameter is added to make it Dry.

https://github.com/ManagedKube/github-action-testkube/blob/3f5a9a46cfd6fb7d56f9acaa44d14c8890e28e8f/entrypoint.sh#L18

**_Evidence of proof_**
- Reference in my pipeline:
![Screen Shot 2022-03-28 at 15 11 32](https://user-images.githubusercontent.com/19688747/160487862-0864fce7-1d40-4b99-ba42-ef90f8571724.png)
- Result:
![Screen Shot 2022-03-28 at 15 12 16](https://user-images.githubusercontent.com/19688747/160487987-a37280f2-1357-4121-9529-6ebbcf78828d.png)

_images are for illustrative purposes only, links to our client are avoided._
 