### PR TITLE
upgraded ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y apt-transport-https gnupg2 curl unzip jq
 


### PR DESCRIPTION
What does this do?

this solution will fix the problem of Testkube build container fail
Tasks related:
https://exactpay.atlassian.net/browse/P2IN-492

WHY:

Support for Ubuntu 21.10 ended on 14th of July 2022
failure was on impish release package that is not available on 21 repo.
HOW:

upgrade ubuntu's version to 22.04 it has all the resources/packages and support from ubuntu.
https://askubuntu.com/questions/1420077/21-10-removed-repositories