### PR TITLE
bugfix: Testkube Wrong Installation  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod 755 ./kubectl
 RUN mv kubectl /usr/local/bin/kubectl
 
 # Install testkube plugin - Specific version of https://github.com/kubeshop/testkube/releases
-ENV TESTKUBE_VERSION=1.12.13
+ENV TESTKUBE_VERSION=1.9.13
 
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod 755 ./kubectl
 RUN mv kubectl /usr/local/bin/kubectl
 
 # Install testkube plugin - Specific version of https://github.com/kubeshop/testkube/releases
-ENV TESTKUBE_VERSION=1.9.13
+ENV TESTKUBE_VERSION=v1.9.13
 
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV TESTKUBE_VERSION=v1.12.13
 
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.
-RUN curl -fsSL -o testkube.sh https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh
+RUN curl -fsSL -o install.sh https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh
 RUN chmod 700 install.sh
 RUN ./install.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,11 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/s
 RUN chmod 700 get_helm.sh
 RUN ./get_helm.sh
 
-# Install testkube plugin - Specific version of https://github.com/kubeshop/testkube/releases
-ENV TESTKUBE_VERSION=v1.12.13
-
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.
 RUN curl -fsSL -o install.sh https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh
-RUN chmod 700 install.sh
-RUN TESTKUBE_VERSION=v1.12.13 ./install.sh
+RUN chmod +x install.sh
+RUN TESTKUBE_VERSION=v1.12.13 bash ./install.sh
 
 # Install aws cli
 ENV AWS_CLI_VERSION=2.9.23

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod 755 ./kubectl
 RUN mv kubectl /usr/local/bin/kubectl
 
 # Install testkube plugin - Specific version of https://github.com/kubeshop/testkube/releases
-ENV TESTKUBE_VERSION=1.9.13
+ENV TESTKUBE_VERSION=1.12.13
 
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV TESTKUBE_VERSION=v1.12.13
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.
 RUN curl -fsSL -o install.sh https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh
 RUN chmod 700 install.sh
-RUN ./install.sh
+RUN TESTKUBE_VERSION=v1.12.13 ./install.sh
 
 # Install aws cli
 ENV AWS_CLI_VERSION=2.9.23

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,20 @@ RUN curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 RUN chmod 755 ./kubectl
 RUN mv kubectl /usr/local/bin/kubectl
 
+
+# Helm installation
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+RUN chmod 700 get_helm.sh
+RUN ./get_helm.sh
+
 # Install testkube plugin - Specific version of https://github.com/kubeshop/testkube/releases
-ENV TESTKUBE_VERSION=v1.9.13
+ENV TESTKUBE_VERSION=v1.12.13
 
 # Note: the new url (https://get.testkube.io) is pointing to https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh 
 # where is using TESTKUBE_VERSION environment variable where you can handle Which version do you want.
-RUN curl -sSLf https://get.testkube.io | sh
+RUN curl -fsSL -o testkube.sh https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh
+RUN chmod 700 install.sh
+RUN ./install.sh
 
 # Install aws cli
 ENV AWS_CLI_VERSION=2.9.23


### PR DESCRIPTION
# What
- Fix error: kubectl testkube unknown command
- Upgrade to new test kube version (1.12.13) (taking advantage about fix)

# How 
- Changing version adding "v" as a prefix.
- Upgrade url raw file https://raw.githubusercontent.com/kubeshop/testkube/main/install.sh

# Evidence of test
- We are using currently branch in the following project. https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1786/files#diff-67560eff786853f9674931363fa90db8e0572771174ecca3449f9cb7d405c3a6R209
- Workflow looks good: https://github.com/exact-payments/gruntwork-infrastructure-live/actions/runs/5487620011/jobs/9999319915?pr=1786#step:15:223
